### PR TITLE
Updates sdk version to match examples

### DIFF
--- a/docs/1-simple-conversation.md
+++ b/docs/1-simple-conversation.md
@@ -153,7 +153,7 @@ In the `build.gradle` file we'll add the Nexmo Conversation Android SDK.
 //app/build.gradle
 dependencies {
 ...
-  compile 'com.nexmo:conversation:0.6.4'
+  compile 'com.nexmo:conversation:0.7.1'
   compile 'com.android.support:appcompat-v7:25.3.1'
 ...
 }


### PR DESCRIPTION
When going through `1-simple-conversation`, the `ChatActivity` code had a bunch of errors relating to `EventListener` and other similar classes not being found. Turns out, the sdk version documented was out of date.